### PR TITLE
fix relative imports for python3

### DIFF
--- a/python/countertimer/HasyVirtualCounterCtrl.py
+++ b/python/countertimer/HasyVirtualCounterCtrl.py
@@ -5,7 +5,8 @@ import time
 # import datetime
 # import sys
 # from HasyVirtualCounterLib import *
-from HasyVirtualCounterLib import reset, myread
+from sardana.PoolController.countertimer.HasyVirtualCounterLib import (
+    reset, myread)
 
 
 class HasyVirtualCounterCtrl(CounterTimerController):


### PR DESCRIPTION
relative imports of `HasyVirtualCounterLib` functions is causing an error when you start Pool in python3