### PR TITLE
change StartOne(self, ind) to StartOne(self, ind, value):

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,13 +1,9 @@
 [flake8]
 exclude=
     .git,
-    docs,
-    doc,
     .eggs,
     dist,
     __pycache__,
-    nxstest,
-    build,
-    lavuetaurus
+    build
 # max-complexity = 10
 # ignore = F401, F403, E722, C901

--- a/python/countertimer/AmptekPX5CoTiCtrl.py
+++ b/python/countertimer/AmptekPX5CoTiCtrl.py
@@ -168,7 +168,7 @@ class AmptekPX5CounterTimerController(CounterTimerController):
     def PreStartOne(self, ind, value):
         return True
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def StartAll(self):
@@ -321,7 +321,7 @@ class AmptekPX5SoftCounterTimerController(CounterTimerController):
     def PreStartOne(self, ind, value):
         return True
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def StartAll(self):

--- a/python/countertimer/DGG2Ctrl.py
+++ b/python/countertimer/DGG2Ctrl.py
@@ -139,7 +139,7 @@ class DGG2Ctrl(CounterTimerController):
     # def PreStartOne(self, ind):
     #     pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         if self.device_available[ind - 1] == 1:
             self.wantedCT.append(ind)
 

--- a/python/countertimer/HasyInterferometerCtrl.py
+++ b/python/countertimer/HasyInterferometerCtrl.py
@@ -74,7 +74,7 @@ class HasyInterferometerCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def ReadOne(self, ind):

--- a/python/countertimer/HasyScaCtrl.py
+++ b/python/countertimer/HasyScaCtrl.py
@@ -99,7 +99,7 @@ class HasyScaCtrl(CounterTimerController):
     def PreStartOne(self, ind, value):
         return True
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         self.wantedCT.append(ind)
 
     def StartAll(self):

--- a/python/countertimer/HasyVirtualCounterCtrl.py
+++ b/python/countertimer/HasyVirtualCounterCtrl.py
@@ -67,7 +67,7 @@ class HasyVirtualCounterCtrl(CounterTimerController):
     def PreStartAll(self):
         pass
 
-    def StartOne(self, axis):
+    def StartOne(self, axis, value):
         reset(self.LibId)
         pass
 

--- a/python/countertimer/KromoRoIsCtrl.py
+++ b/python/countertimer/KromoRoIsCtrl.py
@@ -90,7 +90,7 @@ class KromoRoIsCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         return True
 
     def ReadOne(self, ind):

--- a/python/countertimer/LimaRoICounterCtrl.py
+++ b/python/countertimer/LimaRoICounterCtrl.py
@@ -114,7 +114,7 @@ class LimaRoICounterCtrl(CounterTimerController):
     def PreStartOne(self, ind, value):
         return True
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         self.wantedCT.append(ind)
 
     def StartAll(self):

--- a/python/countertimer/MCAroisCtrl.py
+++ b/python/countertimer/MCAroisCtrl.py
@@ -90,7 +90,7 @@ class MCAroisCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def ReadOne(self, ind):

--- a/python/countertimer/MHzDAQp01Ctrl.py
+++ b/python/countertimer/MHzDAQp01Ctrl.py
@@ -88,7 +88,7 @@ class MHzDAQp01Ctrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         try:
             sta = self.proxy.command_inout("State")
         except Exception:

--- a/python/countertimer/MythenRoisCtrl.py
+++ b/python/countertimer/MythenRoisCtrl.py
@@ -93,7 +93,7 @@ class MythenRoisCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def ReadOne(self, ind):

--- a/python/countertimer/PSCameraVHRRoIsCtrl.py
+++ b/python/countertimer/PSCameraVHRRoIsCtrl.py
@@ -89,7 +89,7 @@ class PSCameraVHRRoIsCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         return True
 
     def ReadOne(self, ind):

--- a/python/countertimer/SIS3302RoisCtrl.py
+++ b/python/countertimer/SIS3302RoisCtrl.py
@@ -104,7 +104,7 @@ class SIS3302RoisCtrl(CounterTimerController):
         if self.FlagMaster == 0:
             self.counts = self.proxy.read_attribute("Count").value
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         return True
 
     def ReadOne(self, ind):

--- a/python/countertimer/SIS3820Ctrl.py
+++ b/python/countertimer/SIS3820Ctrl.py
@@ -137,7 +137,7 @@ class SIS3820Ctrl(CounterTimerController):
             raise RuntimeError("Ctrl Tango's proxy null!!!")
             return False
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         self.wantedCT.append(ind)
 
     def StartAll(self):

--- a/python/countertimer/VFCADCCtrl.py
+++ b/python/countertimer/VFCADCCtrl.py
@@ -145,7 +145,7 @@ class VFCADCCtrl(CounterTimerController):
             raise RuntimeError("Ctrl Tango's proxy null!!!")
             return False
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         # print "PYTHON -> VFCADCCtrl/", self.inst_name,": \
         # In StartOne method for index", ind
         self.wanted.append(ind)

--- a/python/countertimer/XMCDCtrl.py
+++ b/python/countertimer/XMCDCtrl.py
@@ -94,7 +94,7 @@ class XMCDCtrl(CounterTimerController):
     def ReadAll(self):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         pass
 
     def ReadOne(self, ind):

--- a/python/zerod/HasyADCCtrl.py
+++ b/python/zerod/HasyADCCtrl.py
@@ -131,7 +131,7 @@ class HasyADCCtrl(ZeroDController):
     def PreStartOne(self, ind, value):
         pass
 
-    def StartOne(self, ind):
+    def StartOne(self, ind, value):
         # print "PYTHON -> HasyADCCtrl/", self.inst_name,": \
         #     In StartOne method for index", ind
         self.wanted.append(ind)


### PR DESCRIPTION
Hi Teresa,

it looks like `StartOne(self, ind)` needs to be changed to `StartOne(self, ind, value)`. Otherwise I get the following error:
```
SardanaTP.W005 DEBUG    2020-10-28 14:53:17,291 nxsmntgrp.Acquisition.SoftwareAcquisition: StartOne() takes 2 positional arguments but 3 were given
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 904, in start_action
    pool_ctrl.ctrl.StartOne(axis, value)
TypeError: StartOne() takes 2 positional arguments but 3 were given
SardanaTP.W005 DEBUG    2020-10-28 14:53:17,305 nxsmntgrp.Acquisition.SoftwareAcquisition: <- (with Exception) start_action
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 904, in start_action
    pool_ctrl.ctrl.StartOne(axis, value)
TypeError: StartOne() takes 2 positional arguments but 3 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/taurus/core/util/log.py", line 198, in wrapper
    ret = f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 910, in start_action
    raise Exception(msg)
Exception: dgg2_exp_01.StartOne(1) failed
SardanaTP.W005 ERROR    2020-10-28 14:53:17,306 SardanaTP.SardanaTP.W005: Uncaught exception running job 'run' called from thread SardanaTP.W003:
  File "/usr/lib/python3.7/threading.py", line 885, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3/dist-packages/sardana/sardanathreadpool.py", line 58, in run
    Worker.run(self)
  File "/usr/lib/python3/dist-packages/taurus/core/util/threadpool.py", line 147, in run
    cmd(*args, **kw)
  File "/usr/lib/python3/dist-packages/sardana/util/funcgenerator.py", line 194, in run
    self.fire_active()
  File "/usr/lib/python3/dist-packages/sardana/util/funcgenerator.py", line 259, in fire_active
    self.fire_event(EventType("active"), self._id)
  File "/usr/lib/python3/dist-packages/sardana/sardanaevent.py", line 110, in fire_event
    self._fire_event(event_type, event_value, listeners=listeners)
  File "/usr/lib/python3/dist-packages/sardana/sardanaevent.py", line 130, in _fire_event
    real_listener.event_received(self, event_type, event_value)
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 344, in event_received
    **self._sw_acq_args.kwargs)
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 904, in start_action
    pool_ctrl.ctrl.StartOne(axis, value)
TypeError: StartOne() takes 2 positional arguments but 3 were given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/taurus/core/util/threadpool.py", line 147, in run
    cmd(*args, **kw)
  File "/usr/lib/python3/dist-packages/sardana/pool/poolaction.py", line 342, in run
    self.start_action(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 1121, in start_action
    nb_states_per_value, **kwargs)
  File "/usr/lib/python3/dist-packages/taurus/core/util/log.py", line 198, in wrapper
    ret = f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/sardana/pool/poolacquisition.py", line 910, in start_action
    raise Exception(msg)
Exception: dgg2_exp_01.StartOne(1) failed

```